### PR TITLE
Support php8.3 & github actions

### DIFF
--- a/.github/workflows/test-install.yml
+++ b/.github/workflows/test-install.yml
@@ -1,11 +1,11 @@
 name: Install IonCube Loader
 
 on:
-  workflow_dispatch:  # Allows manual triggering of the workflow
+  workflow_dispatch: 
 
 jobs:
   install-ioncube:
-    runs-on: ubuntu-latest  # Use the latest Ubuntu runner
+    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout repository
@@ -18,7 +18,7 @@ jobs:
           extensions: mbstring, xml, curl
 
       - name: Make script executable
-        run: chmod +x ./install-ioncube.sh  # Ensure your script is executable
+        run: chmod +x ./install-ioncube.sh
 
       - name: Run IonCube Loader installation script
         run: |

--- a/.github/workflows/test-install.yml
+++ b/.github/workflows/test-install.yml
@@ -1,0 +1,26 @@
+name: Install IonCube Loader
+
+on:
+  workflow_dispatch:  # Allows manual triggering of the workflow
+
+jobs:
+  install-ioncube:
+    runs-on: ubuntu-latest  # Use the latest Ubuntu runner
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Set up PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.3' 
+          extensions: mbstring, xml, curl
+
+      - name: Make script executable
+        run: chmod +x ./install-ioncube.sh  # Ensure your script is executable
+
+      - name: Run IonCube Loader installation script
+        run: |
+          echo "Proceeding with IonCube installation..."
+          ./install-ioncube.sh

--- a/install-ioncube.sh
+++ b/install-ioncube.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # Copyright (c) 2024 Ángel (Crujera27)
-# Version: 1.4
+# Version: 1.5
 
 echo "WARNING: This script is recommended to be run on a clean system. It may modify your PHP configuration or even break stuff."
 read -p "Do you wish to proceed? (y/n): " proceed_choice
@@ -34,7 +34,8 @@ echo "3. PHP 7.2"
 echo "4. PHP 8.0"
 echo "5. PHP 8.1"
 echo "6. PHP 8.2"
-read -p "Enter your choice (1, 2, 3, 4, 5, or 6): " version_choice
+echo "7. PHP 8.3"
+read -p "Enter your choice (1, 2, 3, 4, 5, 6, or 7): " version_choice
 
 case $version_choice in
     1) PHP_VERSION="7.4";;
@@ -43,6 +44,7 @@ case $version_choice in
     4) PHP_VERSION="8.0";;
     5) PHP_VERSION="8.1";;
     6) PHP_VERSION="8.2";;
+    6) PHP_VERSION="8.3";;
     *) echo "Invalid choice. Exiting."; exit 1;;
 esac
 


### PR DESCRIPTION
This update introduces support for PHP 8.3 in the Bash script designed for installing IonCube Loader. Key modifications include:

    PHP 8.3 Support: A new option was added to the script for selecting PHP 8.3, along with the corresponding logic to handle installation.

    GitHub Actions Workflow: A GitHub Actions workflow was created to automate the execution of the updated script. This includes:
        Triggering the workflow manually via the GitHub UI.
        Setting up the environment using the latest Ubuntu runner.
        Installing PHP 8.3 and required extensions.
        Executing the IonCube Loader installation script.

Overall, these updates enhance the flexibility of the script and enable automated installation through GitHub Actions, making it easier for users to set up IonCube Loader with PHP 8.3.